### PR TITLE
enh: simplify nipype etelemetry ping handling

### DIFF
--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -71,8 +71,9 @@ import os
 from multiprocessing import set_start_method
 
 # Disable NiPype etelemetry always
-_nipype_et = os.getenv("NIPYPE_NO_ET")
+_disable_et = bool(os.getenv("NO_ET") is not None or os.getenv("NIPYPE_NO_ET") is not None)
 os.environ["NIPYPE_NO_ET"] = "1"
+os.environ["NO_ET"] = "1"
 
 try:
     set_start_method('forkserver')
@@ -115,7 +116,7 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 
 # Ping NiPype eTelemetry once if env var was not set
 # workers on the pool will have the env variable set from the master process
-if _nipype_et is None:
+if not _disable_et:
     # Just get so analytics track one hit
     from contextlib import suppress
     from requests import get as _get_url, ConnectionError, ReadTimeout

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -91,7 +91,6 @@ finally:
     from templateflow import __version__ as _tf_ver
     from . import __version__
 
-
 if not hasattr(sys, "_is_pytest_session"):
     sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
 # Disable all warnings in main and children processes only on production versions
@@ -117,9 +116,11 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 # Ping NiPype eTelemetry once if env var was not set
 # workers on the pool will have the env variable set from the master process
 if _nipype_et is None:
-    # check for latest version
-    from nipype import check_latest_version
-    check_latest_version()
+    # Just get so analytics track one hit
+    from contextlib import suppress
+    from requests import get as _get_url, ConnectionError, ReadTimeout
+    with suppress((ConnectionError, ReadTimeout)):
+        _get_url("https://rig.mit.edu/et/projects/nipy/nipype", timeout=0.05)
 
 # Execution environment
 _exec_env = os.name

--- a/fmriprep/config.py
+++ b/fmriprep/config.py
@@ -67,8 +67,12 @@ The :py:mod:`config` is responsible for other conveniency actions.
     :py:class:`~bids.layout.BIDSLayout`, etc.)
 
 """
+import os
 from multiprocessing import set_start_method
 
+# Disable NiPype etelemetry always
+_nipype_et = os.getenv("NIPYPE_NO_ET")
+os.environ["NIPYPE_NO_ET"] = "1"
 
 try:
     set_start_method('forkserver')
@@ -77,7 +81,6 @@ except RuntimeError:
 finally:
     # Defer all custom import for after initializing the forkserver and
     # ignoring the most annoying warnings
-    import os
     import sys
     import random
 
@@ -87,6 +90,7 @@ finally:
     from nipype import logging as nlogging, __version__ as _nipype_ver
     from templateflow import __version__ as _tf_ver
     from . import __version__
+
 
 if not hasattr(sys, "_is_pytest_session"):
     sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
@@ -110,6 +114,14 @@ logging.addLevelName(15, 'VERBOSE')  # Add a new level between INFO and DEBUG
 
 DEFAULT_MEMORY_MIN_GB = 0.01
 
+# Ping NiPype eTelemetry once if env var was not set
+# workers on the pool will have the env variable set from the master process
+if _nipype_et is None:
+    # check for latest version
+    from nipype import check_latest_version
+    check_latest_version()
+
+# Execution environment
 _exec_env = os.name
 _docker_ver = None
 # special variable set in the container
@@ -244,8 +256,6 @@ class nipype(_Config):
 
     crashfile_format = 'txt'
     """The file format for crashfiles, either text or pickle."""
-    disable_telemetry = bool(os.getenv("NIPYPE_NO_ET") is None)
-    """Disable interface telemetry"""
     get_linked_libs = False
     """Run NiPype's tool to enlist linked libraries for every interface."""
     memory_gb = None
@@ -294,12 +304,6 @@ class nipype(_Config):
                 }
             })
             ncfg.enable_resource_monitor()
-
-        if not cls.disable_telemetry:
-            # check for latest version
-            from nipype import check_latest_version
-            check_latest_version()
-            os.environ["NIPYPE_NO_ET"] = "1"
 
         # Nipype config (logs and execution)
         ncfg.update_config({

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     psutil >= 5.4
     pybids >= 0.10.2
     pyyaml
+    requests
     sdcflows ~= 1.3.1
     smriprep ~= 0.6.1
     tedana >= 0.0.9a1, < 0.0.10


### PR DESCRIPTION
Since we are setting pretty up-to-date nipype version restrictions on `setup.cfg`, the version check and logging it are unnecessary and confusing.

But, we still want to record nipype users, so let's just ping manually.